### PR TITLE
corrigindo bug no dataLink de fechamento

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -49,7 +49,7 @@
 		"prefix": "dataLink sdk3",
 		"body": [
 			"<dataLink field='$1'>\n",
-			"</datalink>"
+			"</dataLink>"
 		],
 		"description": "A tag dataLink representa um componente não visual (não é exibido na interface) que monitora mudanças em um NodeDatabase."
 	},


### PR DESCRIPTION
era só um bug que tava enchendo o saco quando eu usava dataLink, onde o segundo estava em minusculo